### PR TITLE
Nightly->Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Game Server Helper
+
+## Release Notes
+
+### Release 07/20/2024
+
+- Added a '--now' function to gsh script use it to immediately stop the factorio container without waiting. Useful if you've just had an autosave happen or you have had something happen that you don't want to be saved to your save file.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 ### Release 07/20/2024
 
-- Added a '--now' function to gsh script use it to immediately stop the factorio container without waiting. Useful if you've just had an autosave happen or you have had something happen that you don't want to be saved to your save file.
+- Added a '--now' function to gsh script, use it to immediately stop the factorio container without waiting. Useful if you've just had an autosave happen or you have had something happen that you don't want to be saved to your save file.

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -16,10 +16,10 @@ then
       do
         if [ $x -gt 0 ]
         then
+          clear
           printf '%dh:%dm:%ds\n' $(($x/3600)) $(($x%3600/60)) $(($x%60))
           x=$((x-1))
           sleep 1
-          clear
         else
           docker compose -f /usr/gsh/docker/factorio/docker-compose.yml down
           break

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -7,20 +7,25 @@ then
     docker compose -f /usr/gsh/docker/factorio/docker-compose.yml up -d
   elif [ "$2" == "down" ]
   then
-    x=$(($(cat /usr/gsh/docker/factorio/config/server-settings.json | grep autosave_interval | awk 'FNR==2{print$0}' | colrm 1 23 | colrm 3)*60))
-    while [ $x -ge 0 ]
-    do
-      if [ $x -gt 0 ]
-      then
-        printf '%dh:%dm:%ds\n' $(($x/3600)) $(($x%3600/60)) $(($x%60))
-        x=$((x-1))
-        sleep 1
-        clear
-      else
-        docker compose -f /usr/gsh/docker/factorio/docker-compose.yml down
-        break
-      fi
-    done
+    if [ "$3" == "--now" ]
+    then
+      docker compose -f /usr/gsh/docker/factorio/docker-compose.yml down
+    else
+      x=$(($(cat /usr/gsh/docker/factorio/config/server-settings.json | grep autosave_interval | awk 'FNR==2{print$0}' | colrm 1 23 | colrm 3)*60))
+      while [ $x -ge 0 ]
+      do
+        if [ $x -gt 0 ]
+        then
+          printf '%dh:%dm:%ds\n' $(($x/3600)) $(($x%3600/60)) $(($x%60))
+          x=$((x-1))
+          sleep 1
+          clear
+        else
+          docker compose -f /usr/gsh/docker/factorio/docker-compose.yml down
+          break
+        fi
+      done
+    fi
   elif [ "$2" == "logs" ]
   then
     docker compose -f /usr/gsh/docker/factorio/docker-compose.yml logs


### PR DESCRIPTION
# Release 07/20/2024

- Added a '--now' function to gsh script, use it to immediately stop the factorio container without waiting. Useful if you've just had an autosave happen or you have had something happen that you don't want to be saved to your save file.