### PR TITLE
Nightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Working on getting bugs worked out for the Satisfactory 1.0 release. I will have
 
 - Changed to Jquery processing for timer function for 'Factorio' as I realized the limitations of the colrm command as I had it configured before
 
-- Changed to acl control of env instead of sudo. The command, if you need to set up more users for access, is `setfacl -m u:${USER}:rw /usr/gsh/environment/donation-ticker.env` . Replace `${USER}` with the username of the user. If not running as root you will need 'sudo' privledges to edit the acl rules, as set forth by the acl package. If adding more than the installing user you may want to add the alias to their `.bashrc` or `.bash_aliases` with the command `"alias gsh='bash /usr/gsh/script-files/gsh'" >> ~/.bashrc` .
+- Changed to acl control of env instead of sudo. The command, if you need to set up more users for access, is `setfacl -m u:${USER}:rw /usr/gsh/environment/donation-ticker.env` . Replace `${USER}` with the username of the user. If not running as root you will need 'sudo' privledges to edit the acl rules, as set forth by the acl package. If adding more than the installing user you may want to add the alias to their `.bashrc` or `.bash_aliases` with the command `echo "alias gsh='bash /usr/gsh/script-files/gsh'" >> ~/.bashrc` .
 
 - A more in depth installer shall be released soon that will account for system-wide aliasing for this script
 

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -474,6 +474,32 @@ else
   elif [ "$1" == "uninstall" ]
   then
     bash /usr/gsh/script-files/uninstall
+  elif [ "$1" == "time" ]
+  then
+    time=$(date | colrm 1 11 | colrm 9)
+    h=$(echo $time | awk -F ":" '{print $1}')
+    m=$(echo $time | awk -F ":" '{print $2}')
+    s=$(echo $time | awk -F ":" '{print $3}')
+    if [ -f /usr/gsh/environment/restart.env ]
+    then
+      source /usr/gsh/environment/restart.env
+    fi
+    if [[ $h -eq $reshr ]]
+    then
+      if [[ $m -eq $resmin ]]
+      then
+        if [ -f /usr/gsh/environment/notification.env ]
+        then
+          source /usr/gsh/environment/notification.env
+          msg="Server restarting in 15 minutes!"
+          curl -u $usr:$pswd -d "$msg" $url
+          echo $msg >> /var/log/gsh/alerts.log
+        else
+          msg="Server restarting in 15 minutes!"
+          echo $msg >> /var/log/gsh/alerts.log
+        fi
+      fi
+    fi
   elif [ "$1" == "--help" ]
   then
     cat /usr/gsh/messages/help/help.txt

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -217,6 +217,13 @@ then
   elif [ "$1" == "uninstall" ]
   then
     bash /usr/gsh/script-files/uninstall
+  elif [ "$1" == "time" ]
+  then
+    time=$(date | colrm 1 11 | colrm 9)
+    h=$(echo $time | awk -F ":" '{print $1}')
+    m=$(echo $time | awk -F ":" '{print $2}')
+    s=$(echo $time | awk -F ":" '{print $3}')
+    printf '%dh:%dm:%ds\n' $h $m $s
   elif [ "$1" == "--help" ]
   then
     cat /usr/gsh/messages/help/help.txt

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -223,7 +223,7 @@ then
     h=$(echo $time | awk -F ":" '{print $1}')
     m=$(echo $time | awk -F ":" '{print $2}')
     s=$(echo $time | awk -F ":" '{print $3}')
-    printf '%d:%d:%d\n' $h $m $s
+    printf '%dd:%dd:%dd\n' $h $m $s
   elif [ "$1" == "--help" ]
   then
     cat /usr/gsh/messages/help/help.txt

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -223,7 +223,26 @@ then
     h=$(echo $time | awk -F ":" '{print $1}')
     m=$(echo $time | awk -F ":" '{print $2}')
     s=$(echo $time | awk -F ":" '{print $3}')
-    printf '%dd:%dd:%dd\n' $h $m $s
+    if [ -f /usr/gsh/environment/restart.env ]
+    then
+      source /usr/gsh/environment/restart.env
+    fi
+    if [[ $h -eq $reshr ]]
+    then
+      if [[ $m -eq $resmin ]]
+      then
+        if [ -f /usr/gsh/environment/notification.env ]
+        then
+          source /usr/gsh/environment/notification.env
+          msg="Server restarting in 15 minutes!"
+          curl -u $usr:$pswd -d "$msg" $url
+          echo $msg >> /var/log/gsh/alerts.log
+        else
+          msg="Server restarting in 15 minutes!"
+          echo $msg >> /var/log/gsh/alerts.log
+        fi
+      fi
+    fi
   elif [ "$1" == "--help" ]
   then
     cat /usr/gsh/messages/help/help.txt

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -140,7 +140,10 @@ then
       done
       docker compose -f $fi down
       sudo sed -i "s.$repvar.$curvar.g" $envfi
-      docker compose -f $fi up -d
+      if [ "$constat" == '"running"' ]
+      then
+        docker compose -f $fi up -d
+      fi
     elif [ "$2" == "--help" ]
     then
       cat /usr/gsh/messages/help/satisfactory-help.txt
@@ -378,6 +381,7 @@ else
     then
       curvar=$(cat $envfi | grep "SKIPUPDATE")
       repvar="SKIPUPDATE=false"
+      constat=$(docker ps -a --format json | grep satisfactory | jq .State)
       sed -i "s.$curvar.$repvar.g" $envfi
       docker compose -f $fi down
       docker compose -f $fi pull
@@ -397,7 +401,10 @@ else
       done
       docker compose -f $fi down
       sed -i "s.$repvar.$curvar.g" $envfi
-      docker compose -f $fi up -d
+      if [ "$constat" == '"running"' ]
+      then
+        docker compose -f $fi up -d
+      fi
     elif [ "$2" == "--help" ]
     then
       cat /usr/gsh/messages/help/satisfactory-help.txt

--- a/gsh/script-files/gsh
+++ b/gsh/script-files/gsh
@@ -223,7 +223,7 @@ then
     h=$(echo $time | awk -F ":" '{print $1}')
     m=$(echo $time | awk -F ":" '{print $2}')
     s=$(echo $time | awk -F ":" '{print $3}')
-    printf '%dh:%dm:%ds\n' $h $m $s
+    printf '%d:%d:%d\n' $h $m $s
   elif [ "$1" == "--help" ]
   then
     cat /usr/gsh/messages/help/help.txt


### PR DESCRIPTION
Changed satisfactory update function to check if the container is running before deciding if it should be started again after the update. Added `gsh time` command to work together with any notification service that allows posting messages with the curl command that sends an alert that the host server is about to restart, enable this command in your `/etc/crontab` or user crontab with `crontab -e` and set it to `*/1 * * * *` to allow it to check every minute for accuracy. Set the environment variables, `reshr` and `resmin`, in the `/usr/gsh/environment/restart.env` to 15 minutes before the host server actually restarts for message accuracy and don't forget to set the `usr`, `pswd`, and `url` variables in the `/usr/gsh/environment/notification.env` file to properly authenticate with your selected, `curl` enabled, notification provider.